### PR TITLE
Fix logo flexbox issues and make logo a link

### DIFF
--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -7,7 +7,13 @@ import { flashActions, userActions } from '../../_actions'
 import logo from '../../images/logo.jpg';
 
 function Logo() {
-  return <img src={logo} className='nav-logo' />;
+  return (
+    <div>
+      <a href='/'>
+        <img src={logo} className='nav-logo' alt="Logo depicting a backpack" />
+      </a>
+    </div>
+  );
 }
 
 const Header = ({ isLoggedIn, logout, persistFlash, history }) => {


### PR DESCRIPTION
This PR fixes the logo's flexbox issues by placing it in a container. The stretching now happens to the container, while the logo retains its proportional dimensions.

I also wrapped the logo in an anchor tag and added an alt tag.